### PR TITLE
Convert NEAT neural networks to TensorFlow neural networks.

### DIFF
--- a/examples/Flappy Bird/flappy.html
+++ b/examples/Flappy Bird/flappy.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html><head>
   <script src="p5.min.js"></script>
   <script src="p5.dom.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.0.0/dist/tf.min.js"></script>
   <link rel="stylesheet" type="text/css" href="style.css">
   <meta charset="utf-8">
 

--- a/examples/Flappy Bird/flappy.html
+++ b/examples/Flappy Bird/flappy.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html><html><head>
   <script src="p5.min.js"></script>
   <script src="p5.dom.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.0.0/dist/tf.min.js"></script>
+  <!-- Required to export to tensorflow -->
+  <!-- <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@1.0.0/dist/tf.min.js"></script> -->
   <link rel="stylesheet" type="text/css" href="style.css">
   <meta charset="utf-8">
 

--- a/examples/Flappy Bird/sketch.js
+++ b/examples/Flappy Bird/sketch.js
@@ -62,11 +62,19 @@ function draw() {
 
     neat.feedForward();
 
-	let desicions = neat.getDesicions();
+	  let desicions = neat.getDesicions();
     for (let i = 0; i < TOTAL; i++) {
       if (desicions[i] === 1) {
         birds[i].up();
       }
+    }
+
+    if(frameCount % 10 == 0) {
+      let net = neat.creatures[neat.bestCreature()].network.getTensorflowModel();
+      let data = birds[neat.bestCreature()].inputss(pipes);
+
+      console.log(net.predict(tf.tensor([data])).array());
+      console.log(desicions[neat.bestCreature()]);
     }
 
     let finish = true;

--- a/examples/Flappy Bird/sketch.js
+++ b/examples/Flappy Bird/sketch.js
@@ -69,14 +69,6 @@ function draw() {
       }
     }
 
-    if(frameCount % 10 == 0) {
-      let net = neat.creatures[neat.bestCreature()].network.getTensorflowModel();
-      let data = birds[neat.bestCreature()].inputss(pipes);
-
-      console.log(net.predict(tf.tensor([data])).array());
-      console.log(desicions[neat.bestCreature()]);
-    }
-
     let finish = true;
     for (let z = 0; z < birds.length; z++) {
       if (!birds[z].dead) {

--- a/lib/NEAT_browser.js
+++ b/lib/NEAT_browser.js
@@ -201,6 +201,7 @@ function Creature(model) {
 
 function Network(model) { // Neural Network.
 	this.layers = [];
+	this.model = model;
 
 	for (let i = 0; i < model.length; i++) { // Init all the layers.
 		this.layers.push(new Layer(model[i].nodeCount, model[i].type, model[i].activationfunc));
@@ -214,6 +215,35 @@ function Network(model) { // Neural Network.
 		for (let i = 0; i < this.layers.length - 1; i++) {
 			this.layers[i].feedForward(this.layers[i + 1]);
 		}
+	}
+
+	this.getTensorflowModel = function () { // Generates a tensorflow model from the current network.
+		let weights = [];
+
+		for(let i = 0; i < this.layers.length - 1; i++) {
+			let weights_ = [];
+			for(let j = 0; j < this.layers[i].nodes.length; j++) {
+				weights_.push(this.layers[i].nodes[j].weights);
+			}
+			weights.push(weights_);
+		}
+
+		// Initialize the input and hidden layers.
+		let input = tf.input({shape: [this.model[0].nodeCount]});
+		let previous = input;
+		for(let i = 1; i < this.model.length - 1; i++) {
+			previous = tf.layers.dense({units: this.model[i].nodeCount, activation: 'relu'}).apply(previous);
+		}
+		// Initialize the output layer.
+		let output = tf.layers.dense({units: this.model[this.model.length - 1].nodeCount, activation: 'softmax'}).apply(previous);
+
+		let model = tf.model({inputs: input, outputs: output});
+		// Set the weights of the model.
+		for(let i = 1; i < this.model.length; i++) {
+			model.layers[i].setWeights([tf.tensor(weights[i - 1], [weights[i-1].length, weights[i-1][0].length], dtype="float32"), tf.fill([2],0, dtype="float32")]);
+		}
+
+		return model;
 	}
 }
 

--- a/lib/NEAT_browser.js
+++ b/lib/NEAT_browser.js
@@ -253,7 +253,7 @@ function Network(model) { // Neural Network.
 
 		// Set the weights of the model to the weights found by NEAT.
 		for(let i = 1; i < this.model.length; i++) {
-			model.layers[i].setWeights([tf.tensor(weights[i - 1], [weights[i-1].length, weights[i-1][0].length], dtype="float32"), tf.fill([2],0, dtype="float32")]);
+			model.layers[i].setWeights([tf.tensor(weights[i - 1], [weights[i-1].length, weights[i-1][0].length], dtype="float32"), tf.fill([this.model[i].nodeCount],0, dtype="float32")]);
 		}
 
 		return model;

--- a/lib/NEAT_browser.js
+++ b/lib/NEAT_browser.js
@@ -136,6 +136,16 @@ function NEAT(config) {
 			throw "Invalid model!";
 		}
 	}
+
+	this.getTensorflowModel = function(index) { // Generate the requested tensorflow model.
+		if (index) {
+			// Generate the model for the index provided.
+			return this.creatures[index].network.getTensorflowModel();
+		} else {
+			// Generate the model the best performing creature.
+			return this.creatures[this.bestCreature()].network.getTensorflowModel();
+		}
+	}
 }
 
 function Creature(model) {
@@ -218,8 +228,9 @@ function Network(model) { // Neural Network.
 	}
 
 	this.getTensorflowModel = function () { // Generates a tensorflow model from the current network.
+		
+		// Collect the weights from each layer in the network.
 		let weights = [];
-
 		for(let i = 0; i < this.layers.length - 1; i++) {
 			let weights_ = [];
 			for(let j = 0; j < this.layers[i].nodes.length; j++) {
@@ -237,8 +248,10 @@ function Network(model) { // Neural Network.
 		// Initialize the output layer.
 		let output = tf.layers.dense({units: this.model[this.model.length - 1].nodeCount, activation: 'softmax'}).apply(previous);
 
+		// Create the model with random weights.
 		let model = tf.model({inputs: input, outputs: output});
-		// Set the weights of the model.
+
+		// Set the weights of the model to the weights found by NEAT.
 		for(let i = 1; i < this.model.length; i++) {
 			model.layers[i].setWeights([tf.tensor(weights[i - 1], [weights[i-1].length, weights[i-1][0].length], dtype="float32"), tf.fill([2],0, dtype="float32")]);
 		}


### PR DESCRIPTION
The added code* enables the export of a NEAT object-oriented neural network to a TensorFlow model.

As I am not experienced with node.js, I only added this to the browser version of the library. If there is a way to optionally import TensorFlow with node (in case someone doesn't want TensorFlow as a dependency), then I would be happy to add this to the node version of the code.